### PR TITLE
[신명희]수정: start.css의 common.css, reset.css 경로 수정

### DIFF
--- a/assets/styles/start/start.css
+++ b/assets/styles/start/start.css
@@ -1,5 +1,5 @@
-@import "./reset.css";
-@import "./common.css";
+@import "../common/reset.css";
+@import "../common/common.css";
 
 /* common.css의 로컬 폰트 적용이 안되는 문제로 인해 파일에 직접 import해서 사용 */
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css");


### PR DESCRIPTION
피드백 후 경로 수정을 했었는데 start.css 내의 common.css와 reset.css의 경로 수정 반영이 되지 않아서 문제가 생기고 있었다.
